### PR TITLE
Allow no FQN names in javadoc

### DIFF
--- a/Discord4J.xml
+++ b/Discord4J.xml
@@ -3,7 +3,6 @@
   <option name="LINE_SEPARATOR" value="&#xA;" />
   <option name="WRAP_COMMENTS" value="true" />
   <JavaCodeStyleSettings>
-    <option name="CLASS_NAMES_IN_JAVADOC" value="2" />
     <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
       <value />
     </option>


### PR DESCRIPTION
Use the default "If not already imported" option for using fully qualified class names in javadoc. We already do this in most places.